### PR TITLE
ISLE v.1.3.0 Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,7 @@ RUN BUILD_DEPS="build-essential \
     libwmf-dev \
     libwebp-dev \
     libwmf-dev \
+    libltdl-dev \
     zlib1g-dev" && \
     ## I believe these are unused and actually install by libavcodec-extra.
     IMAGEMAGICK_LIBS_EXTENDED="libfontconfig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -207,7 +207,7 @@ RUN BUILD_DEPS="build-essential \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV COMPOSER_HASH=${COMPOSER_HASH:-76a7060ccb93902cd7576b67264ad91c8a2700e2} \    
-    FITS_VERSION=${FITS_VERSION:-1.4.1}
+    FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.
 RUN useradd --comment 'Islandora User' --no-create-home -d /var/www/html --system --uid $ISLANDORA_UID --user-group -s /bin/bash islandora && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,7 @@ RUN useradd --comment 'Islandora User' --no-create-home -d /var/www/html --syste
     git clone $ISLE_BUILD_TOOLS_REPO -b $ISLE_BUILD_TOOLS_BRANCH isle_drupal_build_tools && \
     ## Disable Default
     a2dissite 000-default && \
-    a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc && \
+    a2enmod rewrite deflate headers expires proxy proxy_http proxy_html proxy_connect remoteip xml2enc cache_disk && \
     ## Cleanup phase.
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Designed as the webserver (httpd) for ISLE. Hosts Drupal and Islandora modules a
 Based on:  
   - [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
   - [Apache HTTPD 2.4](https://httpd.apache.org/)
-  - [PHP 5.6](https://www.php.net/)
+  - [PHP 7.1](https://www.php.net/)
 
 Contains and Includes:
   - [Composer](https://getcomposer.org)


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (sec updates)
* Server package management updates via `apt-get`
* `PHP` version `7.1` updates
* Upgraded `FITS` to version `1.5.0`
* Upgraded `ImageMagick` to version `7.0.8-64`
* `Composer` upgraded from commit / hash August 2, 2019 to Sept 2, 2019 (still v 1.9.0)