### PR TITLE
Set AllowOverride to All

### DIFF
--- a/rootfs/etc/confd/templates/apache/apache2.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/apache2.conf.tpl
@@ -169,7 +169,7 @@ Include ports.conf
 
 <Directory /var/www/>
 	Options Indexes FollowSymLinks
-	AllowOverride None
+	AllowOverride All
 	Require all granted
 </Directory>
 


### PR DESCRIPTION
As discussed in https://github.com/Islandora-Collaboration-Group/ISLE/issues/362, the `apache2.conf.tpl` template provides the wrong `AllowOverride` setting, which causes my site to fail to use `.htaccess` unless I change the setting manually. This is in conflict with the settings in https://github.com/Islandora-Collaboration-Group/isle-apache/blob/master/rootfs/etc/confd/templates/apache/site_template.conf.tpl#L10, which can get overwritten by the configuration in this file.