### PR TITLE
ISLE v.1.4.2 Release - Security & package updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ RUN BUILD_DEPS="build-essential \
 
 # Composer & FITS ENV
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master replace hash below with most recent hash & FITS https://projects.iq.harvard.edu/fits/downloads
-ENV COMPOSER_HASH=${COMPOSER_HASH:-b9cc694e39b669376d7a033fb348324b945bce05} \
+ENV COMPOSER_HASH=${COMPOSER_HASH:-dd82de6ec1fedb6df56ed1790ce7f8bbbaf802d8} \
     FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `ImageMagick` upgraded to version `7.0.10-1`
* `Composer` upgraded to [commit / hash](https://github.com/composer/composer/commit/b912a45da3e2b22f5cb5a23e441b697a295ba011) March 13th, 2020 (v 1.10.1)
* `OpenJpeg` upgraded to [commit / hash](https://github.com/uclouvain/openjpeg/commit/563ecfb55ca77c0fc5ea19e4885e00f55ec82ca9) Feb 13th, 2020 (v. 2.3.1)