### PR TITLE
Fix for XAMCL, IIIF token challenges

### DIFF
--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -37,7 +37,9 @@
 	ProxyPassReverse /iiif/2 http://image-services:8080/cantaloupe/iiif/2
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
-
+    ## New cantaloupe settings for testing April 2020
+    ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
+    ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.
 	RewriteEngine On
 	RewriteCond %{QUERY_STRING} (.*)(https|http)(?:[^%]|%[0-9A-Fa-f]{2})+(%2Fislandora.*)

--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -38,8 +38,8 @@
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
     ## New cantaloupe settings for testing April 2020
-    ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
-    ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
+	ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
+	ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.
 	RewriteEngine On
 	RewriteCond %{QUERY_STRING} (.*)(https|http)(?:[^%]|%[0-9A-Fa-f]{2})+(%2Fislandora.*)

--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -37,7 +37,7 @@
 	ProxyPassReverse /iiif/2 http://image-services:8080/cantaloupe/iiif/2
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
-    ## New cantaloupe settings for testing April 2020
+	## New cantaloupe settings for testing April 2020
 	ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
 	ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.


### PR DESCRIPTION
Reference https://github.com/Islandora-Collaboration-Group/ISLE/issues/376

Adds new proxy settings for IIIF to allow X-islandora token to work in IAB and Openseadragon viewers for Books and Large Images