### PR TITLE
ISLE-v.1.5 Release - Updated Proxy settings for IIIF and vhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,7 @@ RUN BUILD_DEPS="build-essential \
 
 # Composer & FITS ENV
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master replace hash below with most recent hash & FITS https://projects.iq.harvard.edu/fits/downloads
-ENV COMPOSER_HASH=${COMPOSER_HASH:-dd82de6ec1fedb6df56ed1790ce7f8bbbaf802d8} \
+ENV COMPOSER_HASH=${COMPOSER_HASH:-4d7f8d40f9788de07c7f7b8946f340bf89535453} \
     FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.
@@ -265,8 +265,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       traefik.frontend.entryPoints=http,https
 
 COPY rootfs /
-
-VOLUME /var/www/html
 
 EXPOSE 80
 

--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -37,7 +37,9 @@
 	ProxyPassReverse /iiif/2 http://image-services:8080/cantaloupe/iiif/2
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
-
+    ## New cantaloupe settings for testing April 2020
+    ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
+    ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.
 	RewriteEngine On
 	RewriteCond %{QUERY_STRING} (.*)(https|http)(?:[^%]|%[0-9A-Fa-f]{2})+(%2Fislandora.*)

--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -38,8 +38,8 @@
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
     ## New cantaloupe settings for testing April 2020
-    ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
-    ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
+	ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
+	ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.
 	RewriteEngine On
 	RewriteCond %{QUERY_STRING} (.*)(https|http)(?:[^%]|%[0-9A-Fa-f]{2})+(%2Fislandora.*)

--- a/rootfs/etc/confd/templates/apache/site_template.conf.tpl
+++ b/rootfs/etc/confd/templates/apache/site_template.conf.tpl
@@ -37,7 +37,7 @@
 	ProxyPassReverse /iiif/2 http://image-services:8080/cantaloupe/iiif/2
 	ProxyPass /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2 nocanon
 	ProxyPassReverse /cantaloupe/iiif/2 http://image-services:8080/cantaloupe/iiif/2
-    ## New cantaloupe settings for testing April 2020
+	## New cantaloupe settings for testing April 2020
 	ProxyPassReverseCookiePath /cantaloupe/iiif/2 /iiif/2
 	ProxyPassReverseCookieDomain /cantaloupe/iiif/2 {{getv "/base/domain"}}
 	## Use internal routing for adore-djatoka requests.


### PR DESCRIPTION
* Fix for XAMCL, IIIF token challenge

* Reference Islandora-Collaboration-Group/ISLE#376
  * Adds new proxy settings for IIIF to allow X-islandora token to work in IAB and Openseadragon viewers for Books and Large Images