### PR TITLE
ISLE-v.1.5.2 Release - Sec updates & S6 Overlay upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN GEN_DEP_PACKS="software-properties-common \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ## S6-Overlay @see: https://github.com/just-containers/s6-overlay
-ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.0.0.1}
+ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.1.0.0}
 ADD https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN GEN_DEP_PACKS="software-properties-common \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ## S6-Overlay @see: https://github.com/just-containers/s6-overlay
-ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.0.0.1}
+ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.1.0.0}
 ADD https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz
@@ -209,7 +209,7 @@ RUN BUILD_DEPS="build-essential \
 
 # Composer & FITS ENV
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master replace hash below with most recent hash & FITS https://projects.iq.harvard.edu/fits/downloads
-ENV COMPOSER_HASH=${COMPOSER_HASH:-ed106feacef086c1fe511f535ad3988d383493d9} \
+ENV COMPOSER_HASH=${COMPOSER_HASH:-bd2f321527c963475068e47856547e15fb5992e7} \
     FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN GEN_DEP_PACKS="software-properties-common \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ## S6-Overlay @see: https://github.com/just-containers/s6-overlay
-ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.1.0.0}
+ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.0.0.1}
 ADD https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz
@@ -209,7 +209,7 @@ RUN BUILD_DEPS="build-essential \
 
 # Composer & FITS ENV
 # @see: Composer https://github.com/composer/getcomposer.org/commits/master replace hash below with most recent hash & FITS https://projects.iq.harvard.edu/fits/downloads
-ENV COMPOSER_HASH=${COMPOSER_HASH:-bd2f321527c963475068e47856547e15fb5992e7} \
+ENV COMPOSER_HASH=${COMPOSER_HASH:-ede2f57b5074fa0e21429430dcd521992bfd830f} \
     FITS_VERSION=${FITS_VERSION:-1.5.0}
 
 ## Let's go!  Finalize all remaining: djatoka, composer, drush, fits.


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `S6 overlay` upgraded to [2.1.0.0](https://github.com/just-containers/s6-overlay/releases/tag/v2.1.0.0)
* `ImageMagick` upgraded to version `7.0.10-29`
* `Composer` upgraded to [commit / hash](https://github.com/composer/getcomposer.org/commits/masterede2f57b5074fa0e21429430dcd521992bfd830f) September 11th, 2020 (v 1.10.13)
* `OpenJpeg` upgraded to [commit / hash](https://github.com/uclouvain/openjpeg/commit/0f16986738725799237548ce6a2ea12516850e72) September 16th, 2020 (v. 2.3.1)